### PR TITLE
Add Travis build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ONSdigital/eq-author-prototypes.svg?branch=master)](https://travis-ci.org/ONSdigital/eq-author-prototypes)
+
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
 Below you will find some information on how to perform common tasks.<br>


### PR DESCRIPTION
## Description

This PR adds Travis build status to the README file, so that it displays on GitHub.
This is just a simple change to test that the `master` branch is being built by Travis and that deployments to GitHub pages are successful.