### PR TITLE
Fix React Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,7 +11,7 @@ function requireAll(requireContext) {
 }
 
 function loadStories() {
-  requireAll(require.context("..", true, /story\.js?$/));
+  requireAll(require.context("../src/components", true, /\/story\.js$/));
 }
 
 configure(loadStories, module);


### PR DESCRIPTION
The logic for importing all files called 'story.js' was wrongfully matching against any filename ending with 'story.js' (eg. 'history.js')

Rewrote import logic to only match files with that filename in the /src/components directory
