### PR TITLE
Fix routing so that author deploys correctly to GitHub pages.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,14 @@ import rootReducer from 'reducers'; // Or wherever you keep your reducers
 import App from 'containers/App';
 
 // Create a history of your choosing (we're using a browser history in this case)
-const history = createHistory();
+let basename = ''
+if (process.env.NODE_ENV === 'production') {
+  basename = '/eq-author-prototypes'
+}
+
+const history = createHistory({
+  basename: basename
+})
 
 // Build the middleware for intercepting and dispatching navigation actions
 const middleware = routerMiddleware(history);


### PR DESCRIPTION
## Description
This PR fixes the broken routing on GitHub pages.

Although the authoring prototype was being deployed correctly, routing was broken and lead to 404 error being displayed when the page loads.
This fix sets the `basename` for the router history so that the react router can successfully resolve the correct components to load based on the browser history path.